### PR TITLE
Allow Users To Sign In Using Javascript or Oauth

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -46,6 +46,17 @@ helpers do
     @authenticator ||= Koala::Facebook::OAuth.new(ENV["FACEBOOK_APP_ID"], ENV["FACEBOOK_SECRET"], url("/auth/facebook/callback"))
   end
 
+  # allow for javascript authentication
+  def access_token_from_cookie
+    authenticator.get_user_info_from_cookies(request.cookies)['access_token']
+  rescue => err
+    warn err.message
+  end
+
+  def access_token
+    session[:access_token] || access_token_from_cookie
+  end
+
 end
 
 # the facebook session expired! reset ours and restart the process
@@ -56,12 +67,12 @@ end
 
 get "/" do
   # Get base API Connection
-  @graph  = Koala::Facebook::API.new(session[:access_token])
+  @graph  = Koala::Facebook::API.new(access_token)
 
   # Get public details of current application
   @app  =  @graph.get_object(ENV["FACEBOOK_APP_ID"])
 
-  if session[:access_token]
+  if access_token
     @user    = @graph.get_object("me")
     @friends = @graph.get_connections('me', 'friends')
     @photos  = @graph.get_connections('me', 'photos')
@@ -83,17 +94,21 @@ get "/close" do
   "<body onload='window.close();'/>"
 end
 
-get "/sign_out" do
+# Doesn't actually sign out permanently, but good for testing
+get "/preview/logged_out" do
   session[:access_token] = nil
+  request.cookies.keys.each { |key, value| response.set_cookie(key, '') }
   redirect '/'
 end
 
+
+# Allows for direct oauth authentication
 get "/auth/facebook" do
   session[:access_token] = nil
   redirect authenticator.url_for_oauth_code(:permissions => FACEBOOK_SCOPE)
 end
 
 get '/auth/facebook/callback' do
-	session[:access_token] = authenticator.get_access_token(params[:code])
-	redirect '/'
+  session[:access_token] = authenticator.get_access_token(params[:code])
+  redirect '/'
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -160,9 +160,8 @@
       <% else %>
         <div>
           <h1>Welcome</h1>
-            <a href='/auth/facebook' class="fb_button fb_button_medium">
-              <span class="fb_button_text">Log In</span>
-            </a>
+          <div class="fb-login-button" data-scope="<%= FACEBOOK_SCOPE %>">Log In</div>
+
         </div>
 
       <% end %>


### PR DESCRIPTION
Porting the functionality to better line up with the PHP functionality. We can pull the Auth key directly from oauth, or from a cookie set by Facebook. 

As usual I put a demo on: https://sharp-dusk-7286.herokuapp.com/

With one major difference, the `/sign_out` no longer works (the php doesn't have a sign out option either). You will need to manually remove Facebook permissions for the app or you can use `/preview/logged_out` to get a taste of what it will look like logged out, thought it doesn't actually log you out.
