### PR TITLE
Set a session secret

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@ require "sinatra"
 require 'koala'
 
 enable :sessions
+set :session_secret, ENV['SESSION_KEY'] || 'a super secret session key'
 set :raise_errors, false
 set :show_exceptions, false
 


### PR DESCRIPTION
Currently, if you scale the template app to multiple dynos, each dyno generates its own session secret with which to encrypt the session content. This causes poor performance and 'too many redirects' errors, as requests hit the different dynos and the browser is repeatedly redirected back to Facebook to get an access token.
